### PR TITLE
Fix header background disappearing when SVG is embedded on dark pages

### DIFF
--- a/src/pages/shell.ts
+++ b/src/pages/shell.ts
@@ -159,7 +159,7 @@ export function htmlShell(title: string, body: string, activePage: string): stri
     .ctrl-btn.active { background: var(--green-dim); color: var(--green); border-color: rgba(29,185,84,0.4); }
 
     /* Preview */
-    .preview-wrap { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r); padding: 24px; display: flex; align-items: center; justify-content: center; min-height: 80px; position: relative; overflow: hidden; }
+    .preview-wrap { background: var(--bg); border: 1px solid var(--border); border-radius: var(--r); padding: 24px; display: flex; align-items: center; justify-content: center; min-height: 80px; position: relative; overflow: hidden; }
     .preview-wrap img { max-width: 100%; border-radius: 4px; display: block; }
     .social-preview-wrap { min-height: 460px; padding: 18px; }
     .social-preview-wrap img { max-height: 680px; width: auto; object-fit: contain; border: 1px solid #242424; background: #080808; }

--- a/src/svg/top-artists.ts
+++ b/src/svg/top-artists.ts
@@ -65,25 +65,21 @@ export function svgTopArtists(
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
   <defs>
     <style>text { ${SVG_FONT} }</style>
-    <linearGradient id="hbg" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#0e0e0e"/>
-      <stop offset="100%" stop-color="#141414"/>
-    </linearGradient>
+    <clipPath id="ta-clip">
+      <rect width="${W}" height="${H}" rx="14"/>
+    </clipPath>
   </defs>
-  <!-- Background -->
-  <rect width="${W}" height="${H}" rx="14" fill="#0e0e0e"/>
-  <rect width="${W}" height="${H}" rx="14" fill="none" stroke="#ffffff08" stroke-width="1"/>
-  <!-- Header -->
-  <svg x="0" y="0" width="${W}" height="40" viewBox="0 0 24 24" fill="none">
+  <g clip-path="url(#ta-clip)">
+    <rect width="${W}" height="${H}" fill="#0e0e0e"/>
     <rect width="${W}" height="40" fill="#111111"/>
-  </svg>
-  <text x="${PAD_X}" y="17" font-size="10" fill="#1DB954" font-weight="700" letter-spacing="1.5">SPOTIFY</text>
-  <text x="${PAD_X + 56}" y="17" font-size="10" fill="#333" font-weight="600" letter-spacing="0.5">·</text>
-  <text x="${PAD_X + 64}" y="17" font-size="10" fill="#444" font-weight="500">TOP ARTISTS</text>
-  <text x="${W - PAD_X}" y="17" font-size="9" fill="#333" text-anchor="end">${rangeLabel(range)}</text>
-  <line x1="${PAD_X}" y1="26" x2="${W - PAD_X}" y2="26" stroke="#1f1f1f" stroke-width="1"/>
-  <!-- Cards -->
-  ${cards}
+    <text x="${PAD_X}" y="17" font-size="10" fill="#1DB954" font-weight="700" letter-spacing="1.5">SPOTIFY</text>
+    <text x="${PAD_X + 56}" y="17" font-size="10" fill="#333" font-weight="600" letter-spacing="0.5">·</text>
+    <text x="${PAD_X + 64}" y="17" font-size="10" fill="#444" font-weight="500">TOP ARTISTS</text>
+    <text x="${W - PAD_X}" y="17" font-size="9" fill="#333" text-anchor="end">${rangeLabel(range)}</text>
+    <line x1="${PAD_X}" y1="26" x2="${W - PAD_X}" y2="26" stroke="#1f1f1f" stroke-width="1"/>
+    ${cards}
+  </g>
+  <rect width="${W}" height="${H}" rx="14" fill="none" stroke="#ffffff08" stroke-width="1"/>
 </svg>`;
 }
 

--- a/src/svg/top-tracks.ts
+++ b/src/svg/top-tracks.ts
@@ -61,20 +61,21 @@ export function svgTopTracks(
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
   <defs>
     <style>text { ${SVG_FONT} }</style>
+    <clipPath id="tt-clip">
+      <rect width="${W}" height="${H}" rx="14"/>
+    </clipPath>
   </defs>
-  <!-- Background -->
-  <rect width="${W}" height="${H}" rx="14" fill="#0e0e0e"/>
+  <g clip-path="url(#tt-clip)">
+    <rect width="${W}" height="${H}" fill="#0e0e0e"/>
+    <rect width="${W}" height="40" fill="#111111"/>
+    <text x="${PAD_X}" y="17" font-size="10" fill="#1DB954" font-weight="700" letter-spacing="1.5">SPOTIFY</text>
+    <text x="${PAD_X + 56}" y="17" font-size="10" fill="#333" font-weight="600" letter-spacing="0.5">·</text>
+    <text x="${PAD_X + 64}" y="17" font-size="10" fill="#444" font-weight="500">TOP TRACKS</text>
+    <text x="${W - PAD_X}" y="17" font-size="9" fill="#333" text-anchor="end">${rangeLabel(range)}</text>
+    <line x1="${PAD_X}" y1="26" x2="${W - PAD_X}" y2="26" stroke="#1f1f1f" stroke-width="1"/>
+    ${cards}
+  </g>
   <rect width="${W}" height="${H}" rx="14" fill="none" stroke="#ffffff08" stroke-width="1"/>
-  <!-- Header -->
-  <rect width="${W}" height="40" rx="0" fill="#111111"/>
-  <rect x="0" y="30" width="${W}" height="10" fill="#111111"/>
-  <text x="${PAD_X}" y="17" font-size="10" fill="#1DB954" font-weight="700" letter-spacing="1.5">SPOTIFY</text>
-  <text x="${PAD_X + 56}" y="17" font-size="10" fill="#333" font-weight="600" letter-spacing="0.5">·</text>
-  <text x="${PAD_X + 64}" y="17" font-size="10" fill="#444" font-weight="500">TOP TRACKS</text>
-  <text x="${W - PAD_X}" y="17" font-size="9" fill="#333" text-anchor="end">${rangeLabel(range)}</text>
-  <line x1="${PAD_X}" y1="26" x2="${W - PAD_X}" y2="26" stroke="#1f1f1f" stroke-width="1"/>
-  <!-- Cards -->
-  ${cards}
 </svg>`;
 }
 


### PR DESCRIPTION
The header rect used rx=0 (square corners) while the outer card used rx=14 (rounded), causing header corners to bleed into the card's transparent corner areas. Since the preview container background (#111111) matched the header fill exactly, the header became invisible in the embedded preview.

- Wrap SVG card content in a clipPath clipped to the rounded card shape so header corners no longer escape the card boundary
- Remove the redundant second header rect in top-tracks and the malformed nested <svg> element in top-artists
- Change .preview-wrap background from --surface (#111111) to --bg (#080808) so the header colour is distinguishable from the container background